### PR TITLE
Disable Travis CI build against Ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 rvm:
-- 1.8.7
 - 1.9.3
 - 2.0.0


### PR DESCRIPTION
Dependency `nokogiri` requires Ruby >= 1.9.2.
