### PR TITLE
Fix release notification

### DIFF
--- a/lib/ghn/notification.rb
+++ b/lib/ghn/notification.rb
@@ -67,11 +67,9 @@ class Ghn
 
   class ReleaseNotification < Notification
     def url
-      "https://github.com/#{repo_full_name}/releases/tag/#{tag}"
-    end
-
-    def tag
-      notification[:subject][:title].split(" ")[-1]
+      url = notification[:subject][:url]
+      result = JSON.parse(Net::HTTP.get(URI.parse(url)))
+      result['html_url']
     end
   end
 

--- a/spec/fixtures/release.json
+++ b/spec/fixtures/release.json
@@ -68,7 +68,7 @@
     },
     "subject": {
         "latest_comment_url": "https://api.github.com/repos/yandod/candycane/releases/510313",
-        "title": "CandyCane v0.9.4",
+        "title": "Release v2.0.0: add `-p` option",
         "type": "Release",
         "url": "https://api.github.com/repos/yandod/candycane/releases/510313"
     },

--- a/spec/lib/ghn/notification_spec.rb
+++ b/spec/lib/ghn/notification_spec.rb
@@ -117,10 +117,15 @@ describe Ghn::Notification do
 
   describe Ghn::ReleaseNotification do
     describe '#url' do
+      before do
+        allow(Net::HTTP).
+          to receive(:get).and_return '{"html_url":"https://github.com/yandod/candycane/releases/tag/v2.1.0"}'
+      end
+
       it do
         expect(
           Ghn::ReleaseNotification.new(fixture('release.json'), false).url
-        ).to eq 'https://github.com/yandod/candycane/releases/tag/v0.9.4'
+        ).to eq 'https://github.com/yandod/candycane/releases/tag/v2.1.0'
       end
     end
   end


### PR DESCRIPTION
In Japanese

https://github.com/kyanny/ghn/releases/tag/v2.1.0 のNotificationが
https://github.com/kyanny/ghn/releases/tag/option になるバグを修正しました。

今回`notification[:subject][:title]`は"Release v2.0.0: add `-p` option"を返しますが、
こちらからURLを生成してはいけないと思います。

`notification[:subject][:url]`にアクセスしたらそれっぽい値が取れたので、
こちらからURLを求めました。

正しそうですね。
https://developer.github.com/v3/repos/releases/#get-a-single-release
