### PR TITLE
Fix uninitialized constant Ghn::ReleaseNotification::JSON (NameError)

### DIFF
--- a/lib/ghn.rb
+++ b/lib/ghn.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'octokit'
 require 'ghn/version'
 require 'ghn/aliases'


### PR DESCRIPTION
I found the following problem.

```
$ ghn list
/Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/notification.rb:71:in `url': uninitialized constant Ghn::ReleaseNotification::JSON (NameError)
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/collector.rb:20:in `block in collect'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/collector.rb:19:in `map'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/collector.rb:19:in `collect'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/commands.rb:33:in `block in collect'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/commands.rb:32:in `loop'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/commands.rb:32:in `with_index'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/commands.rb:32:in `collect'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/lib/ghn/commands.rb:12:in `list'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/masutaka/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/ghn-2.4.0/bin/ghn:5:in `<top (required)>'
        from /Users/masutaka/.rbenv/versions/2.2.2/bin/ghn:23:in `load'
        from /Users/masutaka/.rbenv/versions/2.2.2/bin/ghn:23:in `<main>'
```

When I have a release notification(ex. https://github.com/kyanny/ghn/releases/tag/v2.4.0), this problem occurs.
